### PR TITLE
v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 3.0
 
+### 3.0.1
+
+  * __Bug Fix__
+    + The native `couchbase` Mock library uses `options` provided to mutation methods in a very strange way.  It adds a `haskey` property to the provided `options` argument, which is then used for get operations.  This causes a problem if you reuse the options object.  This change clones the `options` object so that your unit tests work as expected.
+
 ### 3.0.0
 
   * __Breaking Changes__

--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -38,7 +38,7 @@ const summarize = function(keys, results) {
 };
 
 const getOptions = function(entry, options) {
-  if (!entry.hasOwnProperty('options')) return options;
+  if (!entry.hasOwnProperty('options')) return Object.assign({}, options);
   if (typeof entry.options === 'undefined') return undefined;
   if (isPojo(entry.options)) return entry.options;
   throw new TypeError('Invalid options value: options must be an object');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "couchbase-promises",
   "longName": "Couchbase Promises",
   "description": "An A+ Promises wrapper for the Couchbase SDK with added support for batch mutation operations.",
-  "version": "3.0.0",
+  "version": "3.0.1",
 
   "dependencies": {
     "bluebird": "~3.4.6",


### PR DESCRIPTION
…ds.  The mock library uses options in add way that can lead to unexpected behaviors if you're reusing an options object over and over again.

- Updating package version.