### PR TITLE
Version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 4.0
+
+### 4.0.0
+
+  * __Breaking Changes__
+    + The `Bucket.prototype.getMultiAsync()` method now resolves with a new summary object, and will not reject if any key fails.
+
+    + Removing most `EventEmitter` methods, as the native Couchbase `Bucket` class no longer exposes the following:
+      - `Bucket.prototype.eventNames()`
+      - `Bucket.prototype.prependListener()`
+      - `Bucket.prototype.prependOnceListener()`
+
+  * __Technical Debt__
+    + Updating `couchbase` to the latest version (2.3.0).
+
 ## 3.0
 
 ### 3.0.1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Just like the [Couchbase Node.js SDK](http://developer.couchbase.com/documentati
 
 Additionally, this library provides enhanced support for bulk operations.  The the native `couchbase` module only provides batch operation support for key lookups (via [`Bucket.prototype.getMulti()`](http://docs.couchbase.com/sdk-api/couchbase-node-client-2.2.5/Bucket.html#getMulti)).  The `couchbase-promises` module provides a extra methods on the `Bucket` class for performing batch operations.  See the [API](#api) documentation for more information.
 
-The current version supports Couchbase Node.js SDK version 2.2.5.
+The current version supports Couchbase Node.js SDK version 2.3.0.
 
 ## Usage
 Usage is almost exactly the same as the native SDK, but with the added ability to use Promises instead of callbacks.
@@ -109,7 +109,7 @@ In addition to the added `*Async()` methods, the `couchbase-promises` module inc
 
       + `defaultOptions`: _(optional)_ default options for each operation.
 
-  * `Bucket.prototype.getAndLockMultiAsync(keys [, defaultOptions])`
+  * `Bucket.prototype.getAndLockMultiAsync(keys [, defaultOptions])`:
     Gets the document for each key, and adds an exclusive lock for each entry.
 
     Returns a `Promise` that resolves with a [`Summary`](#summary) object.  This `Promise` will always be fulfilled.  Any errors that occur will be specified in the resolved `Summary`.
@@ -124,7 +124,7 @@ In addition to the added `*Async()` methods, the `couchbase-promises` module inc
 
       + `defaultOptions`: _(optional)_ default options for each operation.
 
-  * `Bucket.prototype.getAndTouchMultiAsync(docs [, defaultOptions])`
+  * `Bucket.prototype.getAndTouchMultiAsync(docs [, defaultOptions])`:
     Gets the document for each key, sets their TTL value.
 
     Returns a `Promise` that resolves with a [`Summary`](#summary) object.  This `Promise` will always be fulfilled.  Any errors that occur will be specified in the resolved `Summary`.
@@ -138,6 +138,25 @@ In addition to the added `*Async()` methods, the `couchbase-promises` module inc
         - `options`: _(optional)_ object that contains the [options used for getAndTouch](http://docs.couchbase.com/sdk-api/couchbase-node-client-2.2.5/Bucket.html#getAndTouch).  If this key is absent, options provided by `defaultOptions` will be used.  If you provide this key as part of a `docs` entry, but set it to `undefined` or `null` no options will be used on the insert, and regardless of whether or not `defaultOptions` was provided.
 
       + `defaultOptions`: _(optional)_ default options for each operation.
+
+  * `Bucket.prototype.getMultiAsync(keys [, options])`:
+    Gets multiple documents given an array of keys.  The `getMulti()` method is the only batch operation supported by the native `couchbase` module.
+
+    Returns a `Promise`.  This `Promise` will only reject in the event of a catastrophic failure.  Errors for individual keys will not result in a rejection.  The `Promise` will resolve with an object that looks similar to the `Summary` object, and contains the following keys:
+
+      + `hasErrors`: a `Boolean` value indicating whether or not key failed.
+
+      + `errors`: an integer representing the number of failed keys.
+
+      + `results`: the raw results object from the native `getMulti()` method.
+
+    Parameters include:
+
+      + `keys`: _(required)_ an array of strings to lookup.
+
+      + `options`: _(optional)_ an object with the following keys:
+
+        - `batch_size`: _(optional)_ a number that indicates the size of each batch that is used to fetch the specified keys. A batch size of `0` indicates to perform all operations simultaneously.  The default is `0`.
 
   * `Bucket.prototype.getReplicaMultiAsync(keys [, defaultOptions])`:
     Gets documents for the specified keys from replica nodes.

--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -9,6 +9,7 @@ const promises = require('./promises');
 
 const promisify = promises.promisify;
 const promisifyMulti = promises.promisifyMulti;
+const promisifyNativeMulti = promises.promisifyNativeMulti;
 
 const state = new WeakMap();
 const me = (instance) => { return state.get(instance); };
@@ -193,10 +194,6 @@ class Bucket {
     return this;
   }
 
-  eventNames() {
-    return me(this).eventNames();
-  }
-
   get(key, options, callback) {
     return me(this).get(key, options, callback);
   }
@@ -238,8 +235,8 @@ class Bucket {
     return me(this).getMulti(keys, callback);
   }
 
-  getMultiAsync(keys) {
-    return promisify.call(this, this.getMulti, keys);
+  getMultiAsync(keys, options) {
+    return promisifyNativeMulti.call(this, this.getMulti, keys, options);
   }
 
   getReplica(key, options, callback) {
@@ -424,16 +421,6 @@ class Bucket {
 
   once(eventName, listener) {
     me(this).once(eventName, listener);
-    return this;
-  }
-
-  prependListener(eventName, listener) {
-    me(this).prependListener(eventName, listener);
-    return this;
-  }
-
-  prependOnceListener(eventName, listener) {
-    me(this).prependOnceListener(eventName, listener);
     return this;
   }
 

--- a/lib/mock-cluster.js
+++ b/lib/mock-cluster.js
@@ -343,7 +343,7 @@ const setAdd = function(key, value, options, callback) {
     if (!Array.isArray(val))
       return cb(new couchbase.Error('Not a set'));
 
-    if (!val.includes(value)) val.push(value);
+    if (val.indexOf(value) === -1) val.push(value);
 
     self.replace(key, val, (e, r) => {
       if (elv(e)) return cb(e);
@@ -363,7 +363,7 @@ const setExists = function(key, value, options, callback) {
     if (!Array.isArray(val))
       return cb(new couchbase.Error('Not a set'));
 
-    cb(undefined, { cas: res.cas, value: val.includes(value) });
+    cb(undefined, { cas: res.cas, value: val.indexOf(value) !== -1 });
   });
 };
 

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -64,7 +64,7 @@ class Promises {
     return new Promise((fulfill, reject) => {
       const ff = fulfill;
       const rej = reject;
-      args.push(function (err, result) {
+      args.push(function(err, result) {
         if (isFailure(err)) {
           rej(err);
           return err;
@@ -84,6 +84,36 @@ class Promises {
     });
   }
 
+  static promisifyNativeMulti(original) {
+    const method = original;
+    const args = [];
+    for (let i = 1; i < arguments.length; i++) {
+      const arg = arguments[i];
+      if (typeof arg === 'undefined') continue;
+      args.push(arg);
+    }
+    const self = this;
+    return new Promise((fulfill, reject) => {
+      const ff = fulfill;
+      const rej = reject;
+      args.push(function(err, result) {
+        if (typeof err !== 'number' && isFailure(err)) {
+          rej(err);
+          return err;
+        }
+        const ecount = elv.coalesce(err, 0);
+        const res = {
+          hasErrors: ecount > 0,
+          errors: ecount,
+          results: result,
+        };
+        ff(res);
+        return res;
+      });
+      method.apply(self, args);
+    });
+  }
+
   static promisifyMulti(original) {
     const method = original;
     const args = [];
@@ -95,7 +125,7 @@ class Promises {
     const self = this;
     return new Promise((fulfill, reject) => {
       const ff = fulfill;
-      args.push(function (err, result) {
+      args.push(function(err, result) {
         const val = {
           success: !isFailure(err),
           err: err,

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "couchbase-promises",
   "longName": "Couchbase Promises",
   "description": "An A+ Promises wrapper for the Couchbase SDK with added support for batch mutation operations.",
-  "version": "3.0.1",
+  "version": "4.0.0",
 
   "dependencies": {
     "bluebird": "~3.4.6",
-    "couchbase": "~2.2.5",
+    "couchbase": "~2.3.0",
     "elv": "^1.0.1"
   },
   "devDependencies": {

--- a/tests/unit/bucket.js
+++ b/tests/unit/bucket.js
@@ -405,14 +405,6 @@ function test(library, libraryName) {
         });
       });
 
-      describe('#eventNames', () => {
-        it('should return an array', (done) => {
-          const result = bucket.eventNames();
-          assert.isArray(result);
-          done();
-        });
-      });
-
       describe('#get', () => {
         it('should get a document', (done) => {
           bucket.get(strKey, (err, res) => {
@@ -541,10 +533,10 @@ function test(library, libraryName) {
         it('should get multiple documents', (done) => {
           bucket.getMultiAsync([strKey, numKey])
             .then((res) => {
-              assert.property(res, strKey);
-              assert.property(res, numKey);
-              assert.strictEqual(res[strKey].value, testStr);
-              assert.strictEqual(res[numKey].value, testNum);
+              assert.property(res.results, strKey);
+              assert.property(res.results, numKey);
+              assert.strictEqual(res.results[strKey].value, testStr);
+              assert.strictEqual(res.results[numKey].value, testNum);
               done();
             });
         });
@@ -733,10 +725,10 @@ function test(library, libraryName) {
               return bucket.getMultiAsync(['a', 'b'])
             })
             .then((res) => {
-              assert.property(res, 'a');
-              assert.property(res, 'b');
-              assert.strictEqual(res.a.value, docsMap.get('a').value);
-              assert.strictEqual(res.b.value, docsMap.get('b').value);
+              assert.property(res.results, 'a');
+              assert.property(res.results, 'b');
+              assert.strictEqual(res.results.a.value, docsMap.get('a').value);
+              assert.strictEqual(res.results.b.value, docsMap.get('b').value);
               done();
             });
         });
@@ -748,10 +740,10 @@ function test(library, libraryName) {
               return bucket.getMultiAsync(['a', 'b'])
             })
             .then((res) => {
-              assert.property(res, 'a');
-              assert.property(res, 'b');
-              assert.strictEqual(res.a.value, docs.a.value);
-              assert.strictEqual(res.b.value, docs.b.value);
+              assert.property(res.results, 'a');
+              assert.property(res.results, 'b');
+              assert.strictEqual(res.results.a.value, docs.a.value);
+              assert.strictEqual(res.results.b.value, docs.b.value);
               done();
             });
         });
@@ -764,10 +756,10 @@ function test(library, libraryName) {
               return bucket.getMultiAsync(['a', 'b']);
             })
             .then((res) => {
-              assert.property(res, 'a');
-              assert.property(res, 'b');
-              assert.strictEqual(res.a.value, invalidDocs.a.value);
-              assert.strictEqual(res.b.value, invalidDocs.b.value);
+              assert.property(res.results, 'a');
+              assert.property(res.results, 'b');
+              assert.strictEqual(res.results.a.value, invalidDocs.a.value);
+              assert.strictEqual(res.results.b.value, invalidDocs.b.value);
               done();
             });
         });
@@ -1280,22 +1272,6 @@ function test(library, libraryName) {
         });
       });
 
-      describe('#prependListener', () => {
-        it('should return self', (done) => {
-          const result = bucket.prependListener('connect', () => {});
-          assert.strictEqual(result, bucket);
-          done();
-        });
-      });
-
-      describe('#prependOnceListener', () => {
-        it('should return self', (done) => {
-          const result = bucket.prependOnceListener('connect', () => {});
-          assert.strictEqual(result, bucket);
-          done();
-        });
-      });
-
       describe('#prepend', () => {
         it('should prepend value', (done) => {
           bucket.prepend(strKey, 'y', (err, res) => {
@@ -1600,9 +1576,13 @@ function test(library, libraryName) {
               assert.isOk(res);
               return bucket.getMultiAsync(keys);
             })
-            .catch((err) => {
-              assert.strictEqual(err, keys.length);
+            .then((res) => {
+              assert.property(res.results[strKey], 'error');
+              assert.property(res.results[numKey], 'error');
               done();
+            })
+            .catch((err) => {
+              done(err);
             });
         });
 
@@ -1616,9 +1596,13 @@ function test(library, libraryName) {
               assert.isOk(res);
               return bucket.getMultiAsync(keys);
             })
-            .catch((err) => {
-              assert.strictEqual(err, keys.length);
+            .then((res) => {
+              assert.property(res.results[strKey], 'error');
+              assert.property(res.results[numKey], 'error');
               done();
+            })
+            .catch((err) => {
+              done(err);
             });
         });
 
@@ -1632,9 +1616,13 @@ function test(library, libraryName) {
               assert.isOk(res);
               return bucket.getMultiAsync(keys);
             })
-            .catch((err) => {
-              assert.strictEqual(err, keys.length);
+            .then((res) => {
+              assert.property(res.results[strKey], 'error');
+              assert.property(res.results[numKey], 'error');
               done();
+            })
+            .catch((err) => {
+              done(err);
             });
         });
       });


### PR DESCRIPTION
- The Bucket.prototype.getMultiAsync() method now resolves with a new summary object, and will not reject if any key fails.
- Updating unit tests to reflect changes to Bucket.prototype.getMultiAsync().
- Removing deprecated EventEmitter methods.
- Adding Promises.promisifyNativeMulti() to better summarize natively supported batch operations.
- Updating README and CHANGELOG to reflect changes.
- Changing mock-cluster to use indexOf instead of include to support older runtimes.
- Incrementing major version in package.json.