### PR TITLE
move couchbase node to 2.3.4 for bug fixes in latest lib couchbase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 4.0
 
+### 4.2.0
+  * __Technical Debt__
+    + Updating `couchbase` version to 2.3.4.
+
+
 ### 4.1.0
 
   * __Technical Debt__

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "couchbase-promises",
   "longName": "Couchbase Promises",
   "description": "An A+ Promises wrapper for the Couchbase SDK with added support for batch mutation operations.",
-  "version": "4.1.0",
+  "version": "4.2.0",
 
   "dependencies": {
     "bluebird": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 
   "dependencies": {
     "bluebird": "^3.5.0",
-    "couchbase": "~2.3.0",
+    "couchbase": "~2.3.4",
     "elv": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update for newest bug fixes. all tests pass.